### PR TITLE
Alias CLI as 'wx' as well as 'weathereye'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     entry_points={
         'console_scripts': [
             'weathereye=weathereye.cli:main',
+            'wx=weathereye.cli:main',
         ],
     },
     install_requires=requirements,


### PR DESCRIPTION
Added a second command line script called `wx` to allow users to also use a shorter version instead of using `weathereye`